### PR TITLE
Add ability to add svgs recursively

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,23 +3,38 @@
 let mix = require("laravel-mix");
 let fs = require("fs");
 
-function writeJavascript(file, icons, defaultClass) {
+function output(name, attributes) {}
+
+function writeJavascript(file, icons = {}, defaultClass = "") {
   fs.writeFileSync(
     file,
     `
-    const icons = {
-      ${icons}
-    }
+    const icons = {${icons}}
+    const defaultClass = ${defaultClass}
 
-    const globalClass = '${defaultClass}';
+    module.exports = (name, attributes = '') => {
+      var replacement = "<svg ";
 
-    module.exports = (name, classes = '') => {
       if (!icons[name]) {
         console.error('Failed to load SVG ' + name);
-        return '';
+        return;
       }
 
-      return icons[name].replace('<svg ', '<svg class="' + globalClass + ' ' + classes + '"');
+      if (typeof attributes === "object") {
+          for (let property in attributes) {
+              if (attributes.hasOwnProperty(property)) {
+                  let value = typeof attributes[property] == 'string'
+                      ? attributes[property]
+                      : JSON.stringify(attributes[property]);
+
+                  replacement += property + "='" + value + "' ";
+              }
+          }
+      } else {
+          replacement += 'class="' + defaultClass + " " + attributes + '" ';
+      }
+
+      return icons[name].replace('<svg ', replacement);
     };
   `
   );

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-'use strict';
+"use strict";
 
-let mix = require('laravel-mix');
-let fs = require('fs');
+let mix = require("laravel-mix");
+let fs = require("fs");
 
 function writeJavascript(file, icons, defaultClass) {
-  fs.writeFileSync(file, `
+  fs.writeFileSync(
+    file,
+    `
     const icons = {
       ${icons}
     }
@@ -19,27 +21,31 @@ function writeJavascript(file, icons, defaultClass) {
 
       return icons[name].replace('<svg ', '<svg class="' + globalClass + ' ' + classes + '"');
     };
-  `);
+  `
+  );
 }
 
 class SVG {
   register(options) {
-    this.options = Object.assign({
-      class: '',
-      assets: ['./resources/svg/'],
-      output: './resources/js/svg.js',
-    }, options);
+    this.options = Object.assign(
+      {
+        class: "",
+        assets: ["./resources/svg/"],
+        output: "./resources/js/svg.js",
+      },
+      options
+    );
   }
 
   boot() {
-    let icons = '';
+    let icons = "";
 
-    this.options.assets.forEach((path) => {
-      fs.readdirSync(path).forEach(file => {
-        if (!file.endsWith('.svg')) return;
+    this.options.assets.forEach(path => {
+      let files = this.walker(path);
 
-        const iconName = file.replace('.svg', '');
-        const icon = (fs.readFileSync(path + file) + '');
+      files.forEach(file => {
+        const iconName = file.replace(".svg", "");
+        const icon = fs.readFileSync(path + file) + "";
 
         icons += `'${iconName}': \`${icon}\`,\n\r`;
       });
@@ -47,6 +53,24 @@ class SVG {
 
     writeJavascript(this.options.output, icons, this.options.class);
   }
+
+  walker(dir, filelist = [], prefix = "") {
+    let files = fs.readdirSync(dir);
+
+    files.forEach(file => {
+      if (fs.statSync(dir + file).isDirectory()) {
+        let prefix = file + "/";
+
+        filelist = this.walker(dir + prefix, filelist, prefix);
+      } else {
+        if (!file.endsWith("svg")) return;
+
+        filelist.push(prefix + file);
+      }
+    });
+
+    return filelist;
+  }
 }
 
-mix.extend('svg', new SVG());
+mix.extend("svg", new SVG());


### PR DESCRIPTION
Added walker function to recursively search resources/svg folder and append icons such as that if the folder structure is:

```
resources/svg
  icons/
    my-icon.svg
  my-other-icon.svg
```

it'll spit out the icons so they can be used as such:

```js
svg('icons/my-icon')
svg('my-other-icon')
```